### PR TITLE
Add support for more string sizes and speed up decompiler

### DIFF
--- a/BBScript/Config/Instruction.cs
+++ b/BBScript/Config/Instruction.cs
@@ -22,6 +22,9 @@ public enum ArgType
     Enum,
     C16BYTE,
     C32BYTE,
+    C64BYTE,
+    C128BYTE,
+    C256BYTE,
     COperand,
 }
 

--- a/BBScript/Decompiler/BBSDecompiler.cs
+++ b/BBScript/Decompiler/BBSDecompiler.cs
@@ -81,6 +81,30 @@ public static class BBSDecompiler
                             pos += 32;
                             break;
                         }
+                        case ArgType.C64BYTE:
+                        {
+                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 64) + "\"";
+                            val = val.Replace("\0", string.Empty);
+                            expressions.Add(val);
+                            pos += 64;
+                            break;
+                        }
+                        case ArgType.C128BYTE:
+                        {
+                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 128) + "\"";
+                            val = val.Replace("\0", string.Empty);
+                            expressions.Add(val);
+                            pos += 128;
+                            break;
+                        }
+                        case ArgType.C256BYTE:
+                        {
+                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 256) + "\"";
+                            val = val.Replace("\0", string.Empty);
+                            expressions.Add(val);
+                            pos += 256;
+                            break;
+                        }
                         case ArgType.COperand:
                         {
                             var type = BitConverter.ToInt32(bytecode, pos);
@@ -92,8 +116,16 @@ public static class BBSDecompiler
                             }
                             else
                             {
-                                var name = BBSConfig.Instance.Variables!
-                                    .First(x => x.Value == val).Key;
+                                string name;
+                                if (BBSConfig.Instance.Variables!.ContainsValue(val))
+                                {
+                                    name = BBSConfig.Instance.Variables!
+                                        .First(x => x.Value == val).Key;
+                                }
+                                else
+                                {
+                                    name = val.ToString();
+                                }
                                 expressions.Add($"Var({name})");
                             }
                             pos += 4;

--- a/BBScript/Decompiler/BBSDecompiler.cs
+++ b/BBScript/Decompiler/BBSDecompiler.cs
@@ -6,21 +6,18 @@ namespace BBScript.Decompiler;
 
 public static class BBSDecompiler
 {
-    public static string Decompile(byte[] bytecode)
+    public static void Decompile(BinaryReader reader, StreamWriter writer)
     {
-        var output = new StringBuilder();
-        
-        var jumpTableSize = BitConverter.ToInt32(bytecode);
+        var jumpTableSize = reader.ReadInt32();
 
-        var pos = jumpTableSize * 0x24 + 0x4;
+        reader.BaseStream.Position = jumpTableSize * 0x24 + 0x4;
 
         var indentLevel = 0;
 
-        while (pos < bytecode.Length)
+        while (reader.BaseStream.Position < reader.BaseStream.Length)
         {
-            var id = BitConverter.ToInt32(bytecode, pos);
-            pos += 4;
-            
+            var id = reader.ReadInt32();
+
             if (!BBSConfig.Instance.Instructions!.TryGetValue(id, out Instruction? value))
                 throw new KeyNotFoundException($"Instruction {id} not found!");
 
@@ -36,23 +33,21 @@ public static class BBSDecompiler
                         case ArgType.S16:
                         case ArgType.S32:
                         {
-                            var val = BitConverter.ToInt32(bytecode, pos);
+                            var val = reader.ReadInt32();
                             expressions.Add(val.ToString());
-                            pos += 4;
                             break;
                         }
                         case ArgType.U8:
                         case ArgType.U16:
                         case ArgType.U32:
                         {
-                            var val = BitConverter.ToUInt32(bytecode, pos);
+                            var val = reader.ReadUInt32();
                             expressions.Add($"0x{val}");
-                            pos += 4;
                             break;
                         }
                         case ArgType.Enum:
                         {
-                            var val = BitConverter.ToInt32(bytecode, pos);
+                            var val = reader.ReadInt32();
                             if (BBSConfig.Instance.Enums![arg.EnumName!]!.ContainsValue(val))
                             {
                                 expressions.Add(BBSConfig.Instance.Enums![arg.EnumName!]!
@@ -62,54 +57,47 @@ public static class BBSDecompiler
                             {
                                 expressions.Add(val.ToString());
                             }
-                            pos += 4;
                             break;
                         }
                         case ArgType.C16BYTE:
                         {
-                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 16) + "\"";
+                            var val = "\"" + Encoding.ASCII.GetString(reader.ReadBytes(16)) + "\"";
                             val = val.Replace("\0", string.Empty);
                             expressions.Add(val);
-                            pos += 16;
                             break;
                         }
                         case ArgType.C32BYTE:
                         {
-                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 32) + "\"";
+                            var val = "\"" + Encoding.ASCII.GetString(reader.ReadBytes(32)) + "\"";
                             val = val.Replace("\0", string.Empty);
                             expressions.Add(val);
-                            pos += 32;
                             break;
                         }
                         case ArgType.C64BYTE:
                         {
-                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 64) + "\"";
+                            var val = "\"" + Encoding.ASCII.GetString(reader.ReadBytes(64)) + "\"";
                             val = val.Replace("\0", string.Empty);
                             expressions.Add(val);
-                            pos += 64;
                             break;
                         }
                         case ArgType.C128BYTE:
                         {
-                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 128) + "\"";
+                            var val = "\"" + Encoding.ASCII.GetString(reader.ReadBytes(128)) + "\"";
                             val = val.Replace("\0", string.Empty);
                             expressions.Add(val);
-                            pos += 128;
                             break;
                         }
                         case ArgType.C256BYTE:
                         {
-                            var val = "\"" + Encoding.ASCII.GetString(bytecode, pos, 256) + "\"";
+                            var val = "\"" + Encoding.ASCII.GetString(reader.ReadBytes(256)) + "\"";
                             val = val.Replace("\0", string.Empty);
                             expressions.Add(val);
-                            pos += 256;
                             break;
                         }
                         case ArgType.COperand:
                         {
-                            var type = BitConverter.ToInt32(bytecode, pos);
-                            pos += 4;
-                            var val = BitConverter.ToInt32(bytecode, pos);
+                            var type = reader.ReadInt32();
+                            var val = reader.ReadInt32();
                             if (type == 0)
                             {
                                 expressions.Add($"Const({val})");
@@ -128,7 +116,6 @@ public static class BBSDecompiler
                                 }
                                 expressions.Add($"Var({name})");
                             }
-                            pos += 4;
                             break;
                         }
                         default:
@@ -153,24 +140,24 @@ public static class BBSDecompiler
 
             for (var i = 0; i < indentLevel; i++)
             {
-                output.Append('\t');
+                writer.Write('\t');
             }
 
             if (value.Name != null)
             {
-                output.Append(value.Name + "(");
+                writer.Write(value.Name + "(");
             }
             else
             {
-                output.Append("Unknown" + id + "(");
+                writer.Write("Unknown" + id + "(");
             }
             
             for (var i = 0; i < expressions.Count; i++)
             {
-                output.Append(expressions[i]);
-                if (i < expressions.Count - 1) output.Append(", ");
+                writer.Write(expressions[i]);
+                if (i < expressions.Count - 1) writer.Write(", ");
             }
-            output.Append(");\n");
+            writer.Write(");\n");
 
             switch (value.Indent)
             {
@@ -184,11 +171,9 @@ public static class BBSDecompiler
                     indentLevel = 2;
                     break;
                 case IndentType.ScopeEnd:
-                    output.Append('\n');
+                    writer.Write('\n');
                     break;
             }
         }
-        
-        return output.ToString();
     }
 }

--- a/BBScript/Language/BBSInstruction.cs
+++ b/BBScript/Language/BBSInstruction.cs
@@ -78,6 +78,21 @@ public class BBSInstruction : BBSAST
                             throw new InvalidDataException($"Argument {i} should be a string, but it was {(Args.Expressions[i] as BBSExpression)!.Type}");
                         (Args.Expressions[i] as BBSStrExpr)!.Length = 32;
                         break;
+                    case ArgType.C64BYTE:
+                        if ((Args.Expressions[i] as BBSExpression)!.Type != BBSExpressionType.STRING)
+                            throw new InvalidDataException($"Argument {i} should be a string, but it was {(Args.Expressions[i] as BBSExpression)!.Type}");
+                        (Args.Expressions[i] as BBSStrExpr)!.Length = 64;
+                        break;
+                    case ArgType.C128BYTE:
+                        if ((Args.Expressions[i] as BBSExpression)!.Type != BBSExpressionType.STRING)
+                            throw new InvalidDataException($"Argument {i} should be a string, but it was {(Args.Expressions[i] as BBSExpression)!.Type}");
+                        (Args.Expressions[i] as BBSStrExpr)!.Length = 128;
+                        break;
+                    case ArgType.C256BYTE:
+                        if ((Args.Expressions[i] as BBSExpression)!.Type != BBSExpressionType.STRING)
+                            throw new InvalidDataException($"Argument {i} should be a string, but it was {(Args.Expressions[i] as BBSExpression)!.Type}");
+                        (Args.Expressions[i] as BBSStrExpr)!.Length = 256;
+                        break;
                     case ArgType.COperand:
                         if ((Args.Expressions[i] as BBSExpression)!.Type != BBSExpressionType.CONST
                             && (Args.Expressions[i] as BBSExpression)!.Type != BBSExpressionType.VAR)

--- a/BBScript/Program.cs
+++ b/BBScript/Program.cs
@@ -94,8 +94,8 @@ abstract class Program
         BBSConfig.Instance.Enums = config.Enums;
         BBSConfig.Instance.Instructions = config.Instructions;
         
-        var output = BBSDecompiler.Decompile(File.ReadAllBytes(verbs.Input));
-        
-        File.WriteAllText(verbs.Output!, output);
+        using (BinaryReader reader = new BinaryReader(new FileStream(verbs.Input, FileMode.Open, FileAccess.Read)))
+        using (StreamWriter writer = new StreamWriter(new FileStream(verbs.Output!, FileMode.Create, FileAccess.Write)))
+            BBSDecompiler.Decompile(reader, writer);
     }
 }


### PR DESCRIPTION
Adds support for string sizes of 64, 128, and 256 byte sizes and rewrites the decompiler a bit to use a BinaryReader and StreamWriter to speed up decompilation.